### PR TITLE
multiple resetPasswordtokens with different mails

### DIFF
--- a/src/main/java/health/care/booking/models/TokenPasswordReset.java
+++ b/src/main/java/health/care/booking/models/TokenPasswordReset.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class TokenPasswordReset {
 
     @Id
-    private long id;
+    private String id;
     private String token;
     private String mail;
     private LocalDateTime expiryDate;

--- a/src/main/java/health/care/booking/respository/TokenPasswordResetRepository.java
+++ b/src/main/java/health/care/booking/respository/TokenPasswordResetRepository.java
@@ -2,11 +2,14 @@ package health.care.booking.respository;
 
 import health.care.booking.models.TokenPasswordReset;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface TokenPasswordResetRepository  extends MongoRepository<TokenPasswordReset, String> {
     Optional<TokenPasswordReset> findByToken(String token);
 
-    Optional<TokenPasswordReset> deleteAllByMail(String mail);
-
+    Optional<TokenPasswordReset> deleteByMail(String mail);
 }

--- a/src/main/java/health/care/booking/services/PasswordResetService.java
+++ b/src/main/java/health/care/booking/services/PasswordResetService.java
@@ -29,7 +29,8 @@ public class PasswordResetService {
     }
 
     public void sendPasswordResetLink(String mail) {
-        tokenRepository.deleteAllByMail(mail);
+        // Tar bort token kopplad till mejl från databasen
+        tokenRepository.deleteByMail(mail);
         // Genererar en säker token genom UUID
         String token = UUID.randomUUID().toString();
         // spara token till DB


### PR DESCRIPTION
## Vad har gjorts 

Filer som har  redigerats:
  - models: TokenPasswordReset
                    - ändrade Id från long till String
  - repository: TokenPasswordResetrepository
                    - Ändarde metoden deleteAllByMail till deleteByMail
  - service: PasswordresetService
                    - Bytte ut gammal delete metod till ny i sendPasswordResetLink metoden
  
Closes #47 