### PR TITLE
Add documentation to appointment method created with tests.

### DIFF
--- a/documentation/documentation appointment.txt
+++ b/documentation/documentation appointment.txt
@@ -49,3 +49,12 @@ getAppointmentHistoryFromUsernameCaregiver
 http://localhost:8080/appointment/history/2/{username}
 ####################################################
 ####################################################
+
+==============================================
+As a doctor, add documentation to a completed meeting
+PUT http://localhost:8080/appointment/documentation/add
+{
+    "appointmentId": "{id}",
+    "documentation": "A short description about the meeting from doctors pov."
+}
+==============================================

--- a/src/main/java/health/care/booking/controllers/AppointmentController.java
+++ b/src/main/java/health/care/booking/controllers/AppointmentController.java
@@ -1,5 +1,6 @@
 package health.care.booking.controllers;
 
+import health.care.booking.dto.AppointmentAddDocumentation;
 import health.care.booking.dto.AppointmentRequest;
 import health.care.booking.models.Appointment;
 import health.care.booking.models.Availability;
@@ -117,6 +118,17 @@ public class AppointmentController {
             return appointmentService.getAppointmentHistoryFromUsernameCaregiver(user.getId());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Could not get any appointment history from username: " + username + " " + e.getMessage());
+        }
+    }
+
+    @PreAuthorize("hasRole('DOCTOR')")
+    @PutMapping("/documentation/add")
+    public ResponseEntity<?> addDocumentationToAppointment(@Valid @RequestBody AppointmentAddDocumentation dto) {
+        try {
+            appointmentService.addDocumentationToAppointment(dto);
+            return ResponseEntity.ok("Appointment updated with documentation successfully.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         }
     }
 }

--- a/src/main/java/health/care/booking/dto/AppointmentAddDocumentation.java
+++ b/src/main/java/health/care/booking/dto/AppointmentAddDocumentation.java
@@ -1,0 +1,24 @@
+package health.care.booking.dto;
+
+public class AppointmentAddDocumentation {
+    // VARIABLES
+    private String appointmentId;
+    private String documentation;
+
+    // GETTERS SETTERS
+    public String getAppointmentId() {
+        return appointmentId;
+    }
+
+    public void setAppointmentId(String appointmentId) {
+        this.appointmentId = appointmentId;
+    }
+
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    public void setDocumentation(String documentation) {
+        this.documentation = documentation;
+    }
+}

--- a/src/main/java/health/care/booking/models/Appointment.java
+++ b/src/main/java/health/care/booking/models/Appointment.java
@@ -1,5 +1,6 @@
 package health.care.booking.models;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -10,20 +11,14 @@ import java.util.Date;
 public class Appointment {
     @Id
     private String id;
-
     private String patientId;
-
     private String caregiverId;
-
-
     private String reason;
-
-    // datum och tid, vill ni så kan ni ändra till något annat
-    // tex ett fält för datum ett för tid det är upp till er
     private @NotNull Date dateTime;
-
     // använder Enum Status klassen
     private Status status;
+    @Max(500)
+    private String documentation = ""; // This fills in by a doctor after a completed meeting.
 
     public Appointment() {
     }
@@ -77,5 +72,13 @@ public class Appointment {
     public void setReason(String reason) {
         this.reason = reason;
 
+    }
+
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    public void setDocumentation(String documentation) {
+        this.documentation = documentation;
     }
 }

--- a/src/main/java/health/care/booking/services/AppointmentService.java
+++ b/src/main/java/health/care/booking/services/AppointmentService.java
@@ -1,5 +1,6 @@
 package health.care.booking.services;
 
+import health.care.booking.dto.AppointmentAddDocumentation;
 import health.care.booking.models.Appointment;
 import health.care.booking.models.Availability;
 import health.care.booking.models.Status;
@@ -196,6 +197,20 @@ public class AppointmentService {
         availabilityService.addAvailabilityByArray(cancelledAppointmentDates, updatedAvailability.getId());
     }
 
+    public Appointment addDocumentationToAppointment(AppointmentAddDocumentation dto) {
+        // Find appointment
+        Appointment appointmentToAddDokument = appointmentRepository.findById(dto.getAppointmentId())
+                .orElseThrow(() -> new RuntimeException("Could not find appointment."));
+        // Check if appointment already has documentation given
+        if (!appointmentToAddDokument.getDocumentation().isEmpty()) {
+            throw  new IllegalArgumentException("Documentation already exists!");
+        }
+        // Create updated appointment
+        appointmentToAddDokument.setDocumentation(dto.getDocumentation());
+        // Save new appointment
+        appointmentRepository.save(appointmentToAddDokument);
+        return appointmentToAddDokument;
+    }
 
 
 }

--- a/src/test/java/health/care/booking/AppointmentServiceTest.java
+++ b/src/test/java/health/care/booking/AppointmentServiceTest.java
@@ -3,6 +3,7 @@ package health.care.booking;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import health.care.booking.dto.AppointmentAddDocumentation;
 import health.care.booking.models.Appointment;
 import health.care.booking.models.Availability;
 import health.care.booking.models.Status;
@@ -235,6 +236,50 @@ public class AppointmentServiceTest {
         // Assert
         assertEquals(ResponseEntity.ok(List.of(appointment2, appointment1)), response);
         verify(appointmentRepository, times(1)).findAppointmentByCaregiverId(userId);
+    }
+
+    @Test
+    void shouldAddDocumentationToAppointment() {
+        // Arrange
+        Appointment appointment = new Appointment();
+        appointment.setId("666");
+        appointment.setDocumentation("");
+
+        AppointmentAddDocumentation appointmentAddDocumentation = new AppointmentAddDocumentation();
+        appointmentAddDocumentation.setAppointmentId(appointment.getId());
+        appointmentAddDocumentation.setDocumentation("theDocumentation");
+
+        when(appointmentRepository.findById(any())).thenReturn(Optional.of(appointment));
+
+        // Act
+        Appointment addDocumentToAppointment = appointmentService.addDocumentationToAppointment(appointmentAddDocumentation);
+
+        // Assert
+        assertEquals("theDocumentation", addDocumentToAppointment.getDocumentation(), "Failed! Documentation already added!");
+        System.out.println("Success! Documentation added!");
+    }
+
+    @Test
+    void shouldTryToAddDocumentationToAppointmentThatAlreadyHas() {
+        // Arrange
+        Appointment appointment = new Appointment();
+        appointment.setId("666");
+        appointment.setDocumentation("Documentation already added");
+
+        AppointmentAddDocumentation appointmentAddDocumentation = new AppointmentAddDocumentation();
+        appointmentAddDocumentation.setAppointmentId(appointment.getId());
+        appointmentAddDocumentation.setDocumentation("theDocumentation");
+
+        when(appointmentRepository.findById(any())).thenReturn(Optional.of(appointment));
+
+        // Act
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            appointmentService.addDocumentationToAppointment(appointmentAddDocumentation);
+        });
+
+        // Assert
+        assertEquals("Documentation already exists!", exception.getMessage(), "Failed! Documentation could be added!");
+        System.out.println("Success! Documentation failed to be added!");
     }
 
 


### PR DESCRIPTION
## Vad är gjort
Lägga till "documentation" till appointment modellen som denna gången ska vara något doktorn fyller i efter ett avklarat möte likt feedback.

- Uppdatera modell
- Ny metod för att lägga till dokumentation till ett möte
- Uppdaterat dokumentation
- Två nya tester

## Vad ska testas och hur
- Postman, lägg till en dokumentation till ett avklarat möte.
  
  As a doctor, add documentation to a completed meeting
  PUT http://localhost:8080/appointment/documentation/add
  {
      "appointmentId": "{id}",
      "documentation": "A short description about the meeting from doctors pov."
  }
  
- Tester - AppointmentServiceTest
  - shouldAddDocumentationToAppointment
  - shouldTryToAddDocumentationToAppointmentThatAlreadyHas

## Annat 
- Recenserare: 1